### PR TITLE
orca-build: explicitly use references to avoid skopeo errors

### DIFF
--- a/shutit_orca_build.py
+++ b/shutit_orca_build.py
@@ -172,8 +172,8 @@ echo "
 FROM alpine
 CMD echo Hello host && sleep infinity
 EOF''')
-			shutit_session.send('orca-build --output /tmp/oci-image $(pwd)')
-			shutit_session.send('skopeo copy --format v2s2 oci:/tmp/oci-image docker-archive:/home/person/docker-image:latest')
+			shutit_session.send('orca-build -t final --output /tmp/oci-image $(pwd)')
+			shutit_session.send('skopeo copy --format v2s2 oci:/tmp/oci-image:final docker-archive:/home/person/docker-image:latest')
 			shutit_session.logout()
 			shutit.install('docker')
 			shutit_session.pause_point('docker?')


### PR DESCRIPTION
If you just tell skopeo to copy from an OCI image it won't know which
reference you want copied, so you need to explicitly specify it.
orca-builds default tags are pretty awful, so explicitly set the final
tag and then use that with skopeo.

Signed-off-by: Aleksa Sarai <asarai@suse.de>